### PR TITLE
Clang-format

### DIFF
--- a/include/rviz_visual_tools/imarker_simple.h
+++ b/include/rviz_visual_tools/imarker_simple.h
@@ -54,8 +54,8 @@
 
 namespace rviz_visual_tools
 {
-using visualization_msgs::InteractiveMarkerFeedback;
 using visualization_msgs::InteractiveMarkerControl;
+using visualization_msgs::InteractiveMarkerFeedback;
 
 typedef std::function<void(const visualization_msgs::InteractiveMarkerFeedbackConstPtr&)> IMarkerCallback;
 
@@ -67,7 +67,7 @@ geometry_msgs::Pose getIdentityPose()
   pose.orientation.w = 1.0;
   return pose;
 }
-}
+}  // namespace
 
 class IMarkerSimple
 {

--- a/include/rviz_visual_tools/rviz_visual_tools.h
+++ b/include/rviz_visual_tools/rviz_visual_tools.h
@@ -726,7 +726,8 @@ public:
    * \return true on success
    */
   bool publishWireframeCuboid(const Eigen::Isometry3d& pose, double depth, double width, double height,
-                              colors color = BLUE, scales scale = SMALL, const std::string& ns = "Wireframe Cuboid", std::size_t id = 0);
+                              colors color = BLUE, scales scale = XXSMALL, const std::string& ns = "Wireframe Cuboid",
+                              std::size_t id = 0);
 
   /**
    * \brief Publish transformed wireframe cuboid. Useful eg to show an oriented bounding box.
@@ -739,7 +740,7 @@ public:
    * \return true on success
    */
   bool publishWireframeCuboid(const Eigen::Isometry3d& pose, const Eigen::Vector3d& min_point,
-                              const Eigen::Vector3d& max_point, colors color = BLUE, scales scale = SMALL,
+                              const Eigen::Vector3d& max_point, colors color = BLUE, scales scale = XXSMALL,
                               const std::string& ns = "Wireframe Cuboid", std::size_t id = 0);
 
   /**

--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -2152,8 +2152,8 @@ bool RvizVisualTools::publishWireframeCuboid(const Eigen::Isometry3d& pose, doub
 }
 
 bool RvizVisualTools::publishWireframeCuboid(const Eigen::Isometry3d& pose, const Eigen::Vector3d& min_point,
-                                             const Eigen::Vector3d& max_point, colors color, scales scale, const std::string& ns,
-                                             std::size_t id)
+                                             const Eigen::Vector3d& max_point, colors color, scales scale,
+                                             const std::string& ns, std::size_t id)
 {
   // Extract 8 cuboid vertices
   Eigen::Vector3d p1(min_point[0], min_point[1], min_point[2]);


### PR DESCRIPTION
This PR fixes Travis and restore the default value for publishWireframeCuboid's scale from `SMALL` to `XXSMALL`